### PR TITLE
ci(lint): add Ruff linter to CI pipeline

### DIFF
--- a/.github/workflows/ruff_check.yml
+++ b/.github/workflows/ruff_check.yml
@@ -1,0 +1,22 @@
+name: Ruff Linter
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12.4'
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check


### PR DESCRIPTION
This PR introduces Ruff linter to the CI pipeline for enforcing coding standards. It ensures that code consistency is maintained by running Ruff during each pipeline execution.

Key points:
- Integrated Ruff into the CI process.
- Added configuration to automatically run lint checks.